### PR TITLE
Fix Pattern matching header

### DIFF
--- a/src/docs/asciidoc/usage_guide.adoc
+++ b/src/docs/asciidoc/usage_guide.adoc
@@ -321,3 +321,4 @@ Property.def("square(int) >= 0")
 ----
 
 Generators of complex data structures are composed of simple generators.
+


### PR DESCRIPTION
It wasn't parsed properly due to missing empty line after the previous
section.