### PR TITLE
Differentiate between currying and partial application

### DIFF
--- a/src/docs/asciidoc/usage_guide.adoc
+++ b/src/docs/asciidoc/usage_guide.adoc
@@ -131,14 +131,43 @@ include::../../test/java/javaslang/FunctionsDemo.java[tags=liftMethodReference]
 ----
 <1> The lifted function catches the `IllegalArgumentException` and maps it to `None`.
 
+==== Partial application
+Partial application allows you to derive a new function from an existing one by fixing some values.  You can fix one or more parameters, and the number of fixed parameters defines the arity of the new function such that `new arity = (original arity - fixed parameters)`.  The parameters are bound from left to right.
+
+[source,java,indent=0]
+----
+include::../../test/java/javaslang/FunctionsDemo.java[tags=partialApplicationFunction]
+----
+<1> The first parameter `a` is fixed to the value 2.
+
+This can be demonstrated by fixing the first three parameters of a `Function5`, resulting in a `Function2`.
+[source,java,indent=0]
+----
+include::../../test/java/javaslang/FunctionsDemo.java[tags=partialApplicationFunctionArity5]
+----
+<1> The `a`, `b` and `c` parameters are fixed to the values 2, 3 and 1 respectively.
+
+Partial application differs from <<Currying>>, as will be explored in the relevant section.
+
 ==== Currying
-Currying is a technique to partially apply a function by fixing values for some of the parameters. You can fix one or more parameters, depending on the number of parameters. The parameters are bound from left to right.
+Currying is a technique to partially apply a function by fixing a value for one of the parameters, resulting in a `Function1` function that returns a `Function1`.
+
+When a `Function2` is _curried_, the result is indistinguishable from the _partial application_ of a `Function2` because both result in a 1-arity function.
 
 [source,java,indent=0]
 ----
 include::../../test/java/javaslang/FunctionsDemo.java[tags=curryingFunction]
 ----
 <1> The first parameter `a` is fixed to the value 2.
+
+You might notice that, apart from the use of `.curried()`, this code is identical to the 2-arity given example in <<Partial application>>.  With higher-arity functions, the difference becomes clear.
+
+[source,java,indent=0]
+----
+include::../../test/java/javaslang/FunctionsDemo.java[tags=curryingFunctionArity3]
+----
+<1> Note the presence of additional functions in the parameters.
+<2> Further calls to `apply` returns another `Function1`, apart from the final call.
 
 ==== Memoization
 Memoization is a form of caching. A memoized function executes only once and then returns the result from a cache.

--- a/src/test/java/javaslang/FunctionsDemo.java
+++ b/src/test/java/javaslang/FunctionsDemo.java
@@ -111,6 +111,26 @@ public class FunctionsDemo {
     }
 
     @Test
+    public void partialApplicationFunction() {
+        // tag::partialApplicationFunction[]
+        Function2<Integer, Integer, Integer> sum = (a, b) -> a + b;
+        Function1<Integer, Integer> add2 = sum.apply(2); //<1>
+
+        then(add2.apply(4)).isEqualTo(6);
+        // end::partialApplicationFunction[]
+    }
+
+    @Test
+    public void partialApplicationFunctionArity5() {
+        // tag::partialApplicationFunctionArity5[]
+        Function5<Integer, Integer, Integer, Integer, Integer, Integer> sum = (a, b, c, d, e) -> a + b + c + d + e;
+        Function2<Integer, Integer, Integer> add6 = sum.apply(2, 3, 1); //<1>
+
+        then(add6.apply(4, 3)).isEqualTo(13);
+        // end::partialApplicationFunctionArity5[]
+    }
+
+    @Test
     public void curryingFunction() {
         // tag::curryingFunction[]
         Function2<Integer, Integer, Integer> sum = (a, b) -> a + b;
@@ -118,6 +138,16 @@ public class FunctionsDemo {
 
         then(add2.apply(4)).isEqualTo(6);
         // end::curryingFunction[]
+    }
+
+    @Test
+    public void curryingFunctionArity3() {
+        // tag::curryingFunctionArity3[]
+        Function3<Integer, Integer, Integer, Integer> sum = (a, b, c) -> a + b + c;
+        final Function1<Integer, Function1<Integer, Integer>> add2 = sum.curried().apply(2);//<1>
+
+        then(add2.apply(4).apply(3)).isEqualTo(9);//<2>
+        // end::curryingFunctionArity3[]
     }
 
     String methodWhichAccepts3Parameters(String one, String two, String three) {


### PR DESCRIPTION
2 issues:
- The current documentation doesn't give an example of partial application
- The example given for currying is that of a `Function2`, which gives the same result as partial application for that specific case.

This PR adds a section for partial application and updates the section on currying, giving higher arity examples in both cases. 